### PR TITLE
Fix HomePage session handling to resolve build error

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,10 +19,10 @@ import Link from "next/link"
 import { useSession } from "next-auth/react"
 
 export default function HomePage() {
-    return <Login />
-  }
+  const { data: session, status } = useSession()
+
   if (status !== "authenticated" || !session?.user) {
-    return null
+    return <Login />
   }
 
   const stats = [


### PR DESCRIPTION
## Summary
- properly wrap HomePage content behind authentication check using `useSession`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Parsing errors across repo)*
- `npm run build` *(fails: Turbopack build failed with parse errors and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68b7545fc040832189536b80c076d71c